### PR TITLE
Support OOB CPU frequency control for EMR/GNR/SRF/GRR/CWF

### DIFF
--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2427,6 +2427,10 @@ static const struct x86_cpu_id intel_pstate_cpu_oob_ids[] __initconst = {
 	X86_MATCH(ICELAKE_X,		core_funcs),
 	X86_MATCH(SAPPHIRERAPIDS_X,	core_funcs),
 	X86_MATCH(EMERALDRAPIDS_X,	core_funcs),
+	X86_MATCH(GRANITERAPIDS_D,	core_funcs),
+	X86_MATCH(GRANITERAPIDS_X,	core_funcs),
+	X86_MATCH(ATOM_CRESTMONT,	core_funcs),
+	X86_MATCH(ATOM_CRESTMONT_X,	core_funcs),
 	{}
 };
 #endif

--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2431,6 +2431,7 @@ static const struct x86_cpu_id intel_pstate_cpu_oob_ids[] __initconst = {
 	X86_MATCH(GRANITERAPIDS_X,	core_funcs),
 	X86_MATCH(ATOM_CRESTMONT,	core_funcs),
 	X86_MATCH(ATOM_CRESTMONT_X,	core_funcs),
+	X86_MATCH(ATOM_DARKMONT_X,	core_funcs),
 	{}
 };
 #endif

--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2426,6 +2426,7 @@ static const struct x86_cpu_id intel_pstate_cpu_oob_ids[] __initconst = {
 	X86_MATCH(SKYLAKE_X,		core_funcs),
 	X86_MATCH(ICELAKE_X,		core_funcs),
 	X86_MATCH(SAPPHIRERAPIDS_X,	core_funcs),
+	X86_MATCH(EMERALDRAPIDS_X,	core_funcs),
 	{}
 };
 #endif


### PR DESCRIPTION
Support OOB CPU frequency control for EMR/GNR/SRF/GRR/CWF.

Note: this PR also includes all the patches in https://github.com/openvelinux/kernel/pull/60, because it depends on the CWF CPUID support in that PR.

Tests:
The OOB CPU frequency control is only available on certain SKUs. Tested this patch series on regular SKUs and no regression found.