### PR TITLE
Support legacy/noHWP CPU frequency control for GNR/GNR-D

### DIFF
--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2410,6 +2410,8 @@ static const struct x86_cpu_id intel_pstate_cpu_ids[] = {
 	X86_MATCH(TIGERLAKE,		core_funcs),
 	X86_MATCH(SAPPHIRERAPIDS_X,	core_funcs),
 	X86_MATCH(EMERALDRAPIDS_X,      core_funcs),
+	X86_MATCH(GRANITERAPIDS_D,	core_funcs),
+	X86_MATCH(GRANITERAPIDS_X,	core_funcs),
 	{}
 };
 MODULE_DEVICE_TABLE(x86cpu, intel_pstate_cpu_ids);


### PR DESCRIPTION
Support legacy/noHWP CPU frequency control for GNR/GNR-D

Tests:
Legacy/noHWP CPU frequency control is available only on some special SKUs or with certain BIOS option changed.
Tested on regular SKUs and no regression found.