### PR TITLE
Support legacy/noHWP CPU frequency control for GNR/GNR-D for 5.15

### DIFF
--- a/drivers/cpufreq/intel_pstate.c
+++ b/drivers/cpufreq/intel_pstate.c
@@ -2351,6 +2351,8 @@ static const struct x86_cpu_id intel_pstate_cpu_ids[] = {
 	X86_MATCH(TIGERLAKE,		core_funcs),
 	X86_MATCH(SAPPHIRERAPIDS_X,	core_funcs),
 	X86_MATCH(EMERALDRAPIDS_X,      core_funcs),
+	X86_MATCH(GRANITERAPIDS_D,	core_funcs),
+	X86_MATCH(GRANITERAPIDS_X,	core_funcs),
 	{}
 };
 MODULE_DEVICE_TABLE(x86cpu, intel_pstate_cpu_ids);


### PR DESCRIPTION
Support legacy/noHWP CPU frequency control for GNR/GNR-D

Test:
This PR only takes effect on some special SKUs with HWP disabled.
Tested on regular GNR SKUs and no regression found.

1: cpufreq: intel_pstate: Add Granite Rapids support in no-HWP mode
