### PR TITLE
VeLinux: 6.6: Backport Venice essential additional patch for Hwmon and AMD_NB

### DIFF
--- a/arch/x86/include/asm/amd_nb.h
+++ b/arch/x86/include/asm/amd_nb.h
@@ -78,23 +78,6 @@ u16 amd_nb_num(void);
 bool amd_nb_has_feature(unsigned int feature);
 struct amd_northbridge *node_to_amd_nb(int node);
 
-static inline u16 amd_pci_dev_to_node_id(struct pci_dev *pdev)
-{
-	struct pci_dev *misc;
-	int i;
-
-	for (i = 0; i != amd_nb_num(); i++) {
-		misc = node_to_amd_nb(i)->misc;
-
-		if (pci_domain_nr(misc->bus) == pci_domain_nr(pdev->bus) &&
-		    PCI_SLOT(misc->devfn) == PCI_SLOT(pdev->devfn))
-			return i;
-	}
-
-	WARN(1, "Unable to find AMD Northbridge id for %s\n", pci_name(pdev));
-	return 0;
-}
-
 static inline bool amd_gart_present(void)
 {
 	if (boot_cpu_data.x86_vendor != X86_VENDOR_AMD)

--- a/drivers/hwmon/k10temp.c
+++ b/drivers/hwmon/k10temp.c
@@ -159,6 +159,11 @@ static void read_tempreg_nb_f15(struct pci_dev *pdev, u32 *regval)
 			  F15H_M60H_REPORTED_TEMP_CTRL_OFFSET, regval);
 }
 
+static u16 amd_pci_dev_to_node_id(struct pci_dev *pdev)
+{
+	return PCI_SLOT(pdev->devfn) - AMD_NODE0_PCI_SLOT;
+}
+
 static void read_tempreg_nb_zen(struct pci_dev *pdev, u32 *regval)
 {
 	if (amd_smn_read(amd_pci_dev_to_node_id(pdev),


### PR DESCRIPTION
* x86/amd_nb, hwmon: (k10temp): Simplify amd_pci_dev_to_node_id()

**Unit test Results:**

**Without patch: Warning is triggered in dmesg**
```javascript
root@venice-hostos:/home/amd# dmesg | grep k10temp
[  966.092660] WARNING: CPU: 129 PID: 9665 at arch/x86/include/asm/amd_nb.h:94 read_tempreg_nb_zen+0x79/0xb0 [k10temp]
[  966.092674] Modules linked in: binfmt_misc nls_ascii nls_cp437 vfat fat ipmi_ssif joydev hid_generic usbhid hid intel_rapl_msr intel_rapl_common amd64_edac edac_mce_amd ghash_clmulni_intel aesni_intel crypto_simd cryptd cdc_ether usbnet mii evdev kvm_amd snd_pcm ast snd_timer drm_shmem_helper acpi_ipmi snd drm_kms_helper ipmi_si soundcore sp5100_tco rapl ipmi_devintf i2c_algo_bit acpi_cpufreq pcspkr dax_hmem ccp watchdog k10temp ipmi_msghandler button drm fuse loop configfs efivarfs ip_tables x_tables autofs4 ext4 crc32c_generic crc16 mbcache jbd2 dm_mod xhci_pci nvme ehci_pci xhci_hcd ehci_hcd nvme_core tg3 t10_pi usbcore crc32c_intel libphy usb_common crc64_rocksoft i2c_piix4
[  966.092725] RIP: 0010:read_tempreg_nb_zen+0x79/0xb0 [k10temp]
[  966.092761]  k10temp_read+0x102/0x290 [k10temp]
root@venice-hostos:/home/amd# dmesg | grep -i "AMD Northbridge"
[  966.092638] Unable to find AMD Northbridge id for 0000:00:19.3
root@venice-hostos:/home/amd#

```

**With patch: No warnings in dmesg**
