### PR TITLE
VeLinux: 6.6: Backport Venice essential additional crash fix patch

### DIFF
--- a/fs/sysfs/group.c
+++ b/fs/sysfs/group.c
@@ -33,10 +33,10 @@ static void remove_files(struct kernfs_node *parent,
 
 static umode_t __first_visible(const struct attribute_group *grp, struct kobject *kobj)
 {
-	if (grp->attrs && grp->is_visible)
+	if (grp->attrs && grp->attrs[0] && grp->is_visible)
 		return grp->is_visible(kobj, grp->attrs[0], 0);
 
-	if (grp->bin_attrs && grp->is_bin_visible)
+	if (grp->bin_attrs && grp->bin_attrs[0] && grp->is_bin_visible)
 		return grp->is_bin_visible(kobj, grp->bin_attrs[0], 0);
 
 	return 0;


### PR DESCRIPTION
**VeLinux: 6.6: Backport Venice essential additional crash fix patch**

* sysfs: Fix crash on empty group attributes array

**Note:** The upstream kernel had reported a crash issue, which has now been resolved by applying the upstream patch (https://github.com/torvalds/linux/commit/cd69fedf58f8ab1ab511f7c6ac1969cebf1c935f). This patch was previously missed in the Venice patch list.

The issue was observed on Intel machines, and the fix has already been merged into the upstream kernel. Therefore, this patch needs to be included in the Venice branch to ensure stability.

Additionally, the same patch should be incorporated into the Velinux kernel to prevent similar crashes.
